### PR TITLE
Update for Python Versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,14 @@
 Vondrák's Long Term Precession Model
 ====================================
 
-.. image:: https://travis-ci.org/digitalvapor/vondrak.svg
-    :target: https://travis-ci.org/digitalvapor/vondrak
+.. image:: https://img.shields.io/pypi/pyversions/vondrak
+   :alt: PyPI - Python Version
+
+.. image:: https://img.shields.io/github/license/dreamalligator/vondrak
+   :alt: GitHub License
+
+.. image:: https://img.shields.io/pypi/v/vondrak
+   :alt: PyPI - Version
 
 A Python implementation of Vondrák's long term precession model and Fortran code.
 
@@ -28,6 +34,10 @@ Documentation
 =============
 
 View the docs at `digitalvapor.github.io/vondrak <https://digitalvapor.github.io/vondrak>`_, or generate with ``make html`` in the ``docs`` folder.
+
+Development
+=====
+Setup a conda environment by simply running ``conda env create --file environment.yml`` and activate by ``conda activate vondrak``
 
 Tests
 =====

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: vondrak
+channels:
+  - conda-forge
+dependencies:
+  - python<3.13 # max current support 3.12
+  - numpy
+  - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,6 @@ name: vondrak
 channels:
   - conda-forge
 dependencies:
-  - python<3.13 # max current support 3.12
+  - python<3.14 # max current support 3.13
   - numpy
   - pytest

--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Scientific/Engineering :: Astronomy'
     ],
     tests_require=['pytest'])

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Scientific/Engineering :: Astronomy'
     ],
     tests_require=['pytest'])


### PR DESCRIPTION
The current status of [Python has support for 3.9 - 3.13](https://devguide.python.org/versions/), with the previous versions in end-of-life. 

Since vondrak only uses `pytest` and `numpy` there aren't any structural changes I could see that needed to be updated to work with the newer versions. Running `pytests` for the package with the newer python versions didn't create any issues/warnings, so it seems to be working as expected.

The new badges on the README.rst are pulled from the details from the PyPi site (for version number and python support) so they are based on the data from the most recent PyPi release (from 2014).

I also added a conda build file and a few lines about how to use it to make development easier.