### PR TITLE
Migrate from Travis-CI to GH and other upkeep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,25 +7,18 @@ jobs:
     strategy:
       matrix:
         python-version:
-          # - '2.6'
-          # - '2.7'
-          # - '3.2'
-          # - '3.3'
-          # - '3.4'
-          # - '3.5'
-          # - '3.6'
-          # - '3.7'
-          # - '3.8'
-          # - '3.9'
-          # - '3.10'
+          - '3.8'
+          - '3.9'
+          - '3.10'
           - '3.11'
-          # - '3.12'
-          # - '3.13'
+          - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - run: pip install numpy pytest
       - run: pytest
   docs:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+on:
+  - push
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          # - '2.6'
+          # - '2.7'
+          # - '3.2'
+          # - '3.3'
+          # - '3.4'
+          # - '3.5'
+          # - '3.6'
+          # - '3.7'
+          # - '3.8'
+          # - '3.9'
+          # - '3.10'
+          - '3.11'
+          # - '3.12'
+          # - '3.13'
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install numpy pytest
+      - run: pytest
+  docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./vondrak/docs
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install -r requirements.txt
+      - run: jupyter nbconvert examples.ipynb --to rst
+      - run: make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
       - run: pytest
   docs:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./vondrak/docs
     steps:
       - uses: actions/checkout@v4
       - run: pip install -r requirements.txt
+      - run: sudo apt install pandoc
       - run: jupyter nbconvert examples.ipynb --to rst
+        working-directory: ./vondrak/docs
       - run: make html
+        working-directory: ./vondrak/docs

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build
 __pycache__
 .cache
 .eggs
+
+# assuming virtual env name is .venv via `python -m venv .venv`
+.venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: python
-python: ['2.6','2.7','3.2','3.3','3.4', '3.5']
-install: pip install -q -e .
-script: py.test

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Tom Spalding and available under the MIT license:
+Copyright (c) 2024 Tom Spalding and available under the MIT license:
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,9 @@ Setup a conda environment by simply running ``conda env create --file environmen
 Tests
 =====
 
-Tests use the `pyttest <https://github.com/pytest-dev/pytest>`_ framework. Simply run ``py.test``.
+Tests use the `pyttest <https://github.com/pytest-dev/pytest>`_ framework. Simply run ``pytest``.
 
 License
 =======
 
-This work is licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License <http://creativecommons.org/licenses/by-sa/4.0/>`_.
+MIT

--- a/README.rst
+++ b/README.rst
@@ -26,14 +26,14 @@ The only dependency is `numpy <https://github.com/numpy/numpy>`_.
 Install
 =======
 
-To install the `Vondrak Python package <https://pypi.python.org/pypi/vondrak>`_ via `PyPI <https://pypi.python.org/pypi>`_, simply ``pip3 install vondrak``. For Python 2, use ``pip``. All code is hosted at `github.com/digitalvapor/vondrak <https://github.com/digitalvapor/vondrak>`_.
+To install the `Vondrak Python package <https://pypi.python.org/pypi/vondrak>`_ via `PyPI <https://pypi.python.org/pypi>`_, simply ``pip3 install vondrak``. For Python 2, use ``pip``. All code is hosted at `github.com/dreamalligator/vondrak <https://github.com/dreamalligator/vondrak>`_.
 
-Alternatively, clone the repo ``git clone https://github.com/digitalvapor/vondrak``, and install from source with ``python3 setup.py install``.
+Alternatively, clone the repo ``git clone https://github.com/dreamalligator/vondrak``, and install from source with ``python3 setup.py install``.
 
 Documentation
 =============
 
-View the docs at `digitalvapor.github.io/vondrak <https://digitalvapor.github.io/vondrak>`_, or generate with ``make html`` in the ``docs`` folder.
+View the docs at `dreamalligator.github.io/vondrak <https://dreamalligator.github.io/vondrak>`_, or generate with ``make html`` in the ``docs`` folder.
 
 Development
 =====

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# required
+numpy
+
+# tests
+pytest
+
+# docs
+sphinx
+jupyterlab

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ pytest
 # docs
 sphinx
 jupyterlab
+
+# vondrak dev mode
+# https://setuptools.pypa.io/en/latest/userguide/development_mode.html
+--editable .

--- a/scripts/setup_dev
+++ b/scripts/setup_dev
@@ -2,5 +2,20 @@
 
 # https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#create-and-use-virtual-environments
 
-sudo apt install \
+#
+# 1. install dev deps
+#
+
+sudo apt install -y \
+  pandoc \
   python3-venv
+
+#
+# 2. create virtual env
+#
+#   python -m venv .venv
+#
+# 3. activate virtual env
+#
+#   source .venv/bin/activate
+#

--- a/scripts/setup_dev
+++ b/scripts/setup_dev
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#create-and-use-virtual-environments
+
+sudo apt install \
+  python3-venv

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ setup(
     description=("A Python implementation of Vondrák's long term precession "
                  "model and Fortran code."),
     long_description=long_description_readme,
-    url='https://github.com/digitalvapor/vondrak',
-    download_url='https://github.com/digitalvapor/vondrak/tarball/{0}'
+    url='https://github.com/dreamalligator/vondrak',
+    download_url='https://github.com/dreamalligator/vondrak/tarball/{0}'
         .format(__version__),
     author='Tom Spalding',
-    author_email='tom@antivapor.net',
+    author_email='tom@blackforestbotanics.com',
     keywords=['astronomy', 'precession', 'vondrak', 'space', 'proper motion'],
     license='MIT',
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     },
     install_requires=['numpy'],
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',

--- a/vondrak/__init__.py
+++ b/vondrak/__init__.py
@@ -2,7 +2,7 @@
 from numpy import array, sin, cos, sqrt, append
 import math
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 
 # 2Pi
 TAU = 6.283185307179586476925287e0

--- a/vondrak/__init__.py
+++ b/vondrak/__init__.py
@@ -2,7 +2,7 @@
 from numpy import array, sin, cos, sqrt, append
 import math
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 # 2Pi
 TAU = 6.283185307179586476925287e0

--- a/vondrak/docs/README.md
+++ b/vondrak/docs/README.md
@@ -1,0 +1,3 @@
+* `pip install -r requirements.txt`
+* `jupyter nbconvert examples.ipynb --to rst`
+* `make html`

--- a/vondrak/docs/conf.py
+++ b/vondrak/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'vondrak'
-copyright = u'2014, Tom Spalding'
+copyright = u'2024, Tom Spalding'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/vondrak/docs/index.rst
+++ b/vondrak/docs/index.rst
@@ -13,8 +13,8 @@ You can also visit:
 
 * Official `Python Package Index <https://pypi.python.org/pypi/vondrak>`_
   entry
-* GitHub `project page <https://github.com/digitalvapor/vondrak/>`_
-* GitHub `issue tracker <https://github.com/digitalvapor/vondrak/issues>`_
+* GitHub `project page <https://github.com/dreamalligator/vondrak/>`_
+* GitHub `issue tracker <https://github.com/dreamalligator/vondrak/issues>`_
 
 Table of Contents
 =================

--- a/vondrak/docs/installation.rst
+++ b/vondrak/docs/installation.rst
@@ -5,10 +5,10 @@ There is only one dependency for Vondrak, `NumPy <http://www.numpy.org/>`_. You 
 
     ``pip3 install vondrak``
 
-Alternatively, clone the repo ``git clone https://github.com/digitalvapor/vondrak``, and install from source with ``python3 setup.py install``.
+Alternatively, clone the repo ``git clone https://github.com/dreamalligator/vondrak``, and install from source with ``python3 setup.py install``.
 
 If you have any problems with installation, or would like to suggest an improvement, simply create an issue on the project's Github page:
 
-    https://github.com/digitalvapor/vondrak
+    https://github.com/dreamalligator/vondrak
 
 Cheers!

--- a/vondrak/docs/readme.md
+++ b/vondrak/docs/readme.md
@@ -1,2 +1,0 @@
-* `ipython nbconvert examples.ipynb --to rst`
-* `make html`


### PR DESCRIPTION
Primarily moving from Travis-CI to Github Workflows. 

Some etc changes to align license mentions and things like that. 

Related changes:

* https://github.com/dreamalligator/vondrak/pull/3 by @cyschneck.